### PR TITLE
Minor punctuation changes

### DIFF
--- a/celebracje-liturgiczne/nabozenstwa.md
+++ b/celebracje-liturgiczne/nabozenstwa.md
@@ -44,11 +44,11 @@ W nawiasach podano dodatkowe informacje dla kadzidła, które nie jest obowiązk
 Wychodzimy z zakrystii w procesji \(kadzidło idzie pierwsze\), dzwonimy dzwonkiem.
 
 Po przyjściu do stopni ołtarza, wszyscy przyklękamy \(turyfer i nawikulariusz czynią głęboki skłon\) i klękamy na oba kolana, śpiewana jest pieśń na wystawienie – dzwonimy dzwonkami.  
-Kapłan wystawia Najświętszy Sakrament na ołtarzu i wraca przed stopnie. \(Następuje zasypanie kadzidła i okadzenie. Po okadzeniu turyfer wraz z nawikulariuszem odnosi trybularz do zakrystii i wraca do ławki.\)  
+Kapłan wystawia Najświętszy Sakrament na ołtarzu i wraca przed stopnie. \(Następuje zasypanie kadzidła i okadzenie. Po okadzeniu turyfer wraz z nawikulariuszem odnosi trybularz do zakrystii i wraca do ławki\).  
 Rozpoczynają się modlitwy.
 
-Po odmówieniu tekstów nabożeństwa, często występuje "czytanka", podczas której siadamy. \(W trakcie "czytanki" turyfer wraz z nawikulariuszem udaje się po kadzidło i czeka w zakrystii na śpiew.\)  
-Po skończonej "czytance", wracamy przed stopnie i klękamy śpiewając pieśń przed błogosławieństwem, dzwonimy dzwonkami. \(Następuje zasypanie kadzidła i okadzenie.\)
+Po odmówieniu tekstów nabożeństwa, często występuje "czytanka", podczas której siadamy. \(W trakcie "czytanki" turyfer wraz z nawikulariuszem udaje się po kadzidło i czeka w zakrystii na śpiew\).  
+Po skończonej "czytance", wracamy przed stopnie i klękamy śpiewając pieśń przed błogosławieństwem, dzwonimy dzwonkami. \(Następuje zasypanie kadzidła i okadzenie\).
 
 Po zakończeniu pieśni kapłan wstaje i odczytuje modlitwę przed błogosławieństwem Najświętszym Sakramentem.  
 Po niej ministrant zakłada welon naramienny kapłanowi, bierze dzwonki i zanosi je na miejsce. Klęka obok gongu i uderza w jeden ton \(poziom\) 3x – 1x podczas podniesienia Najświętszego Sakramentu na wprost, 1x na lewo i 1x na prawo. \(Turyfer udaje się na środek, może uklęknąć na klęczniku, posadzce lub stopniu i [okadza](../funkcje.md#okadzenie) Najświętszy Sakrament tak jak podczas przeistoczenia\).  

--- a/celebracje-liturgiczne/roraty.md
+++ b/celebracje-liturgiczne/roraty.md
@@ -2,7 +2,7 @@
 
 ## Czym są Roraty?
 
-Roraty \(od łac. _Rorate caeli desuper_ **¹** – introitu wg. formularza Mszy o Najświętszej Maryi Pannie w Adwencie\) – pierwsza msza o wschodzie słońca w Okresie Adwentu \(obecnie ze względów duszpasterskich celebracje Rorat przenosi się na godziny popołudniowe\). Jest to msza wotywna \(msza odprawiana nie według formularza przypisanego na dany dzień, lecz według formularza odpowiadającego pobożności wiernych lub szczególnej okazji\) o Najświętszej Maryi Pannie.
+Roraty \(od łac. _Rorate caeli desuper_ **¹** – introitu wg formularza Mszy o Najświętszej Maryi Pannie w Adwencie\) – pierwsza msza o wschodzie słońca w Okresie Adwentu \(obecnie ze względów duszpasterskich celebracje Rorat przenosi się na godziny popołudniowe\). Jest to msza wotywna \(msza odprawiana nie według formularza przypisanego na dany dzień, lecz według formularza odpowiadającego pobożności wiernych lub szczególnej okazji\) o Najświętszej Maryi Pannie.
 
 ## Symbolika
 

--- a/funkcje.md
+++ b/funkcje.md
@@ -15,14 +15,14 @@ Ministrant przygotowuje Eucharystię jak niegdyś uczniowie Paschę Chrystusa:
 * Jeżeli przy rozkładaniu kielicha jednocześnie jest wnoszony Mszał, powinniśmy wzajemnie na siebie czekać aby przyjście i odejście obu ministrantów było w miarę symetryczne i zgrane.
 * Jeżeli dodatkowo została przygotowana puszka lub głęboka patena do konsekracji, możemy poprosić drugiego ministranta aby nam pomógł ją zanieść. 
 * Po skończonej modlitwie wiernych podchodzimy do ołtarza, skłaniamy głowę i kładziemy kielich nieco po jego prawej stronie.
-* \(Zdejmujemy welon kielichowy, jeżeli jest i składamy go po prawej stronie ołtarza.\) Zdejmujemy korporał i kładziemy go na środku ołtarza. Rozkładamy go na prawo i lewo, a następnie w górę i w dół. Jeżeli korporał jest źle zaprasowany i trzeba go odwrócić, uważamy aby ewentualne fragmenty Ciała Pańskiego nie upadły na ołtarz.
+* \(Zdejmujemy welon kielichowy, jeżeli jest i składamy go po prawej stronie ołtarza\).Zdejmujemy korporał i kładziemy go na środku ołtarza. Rozkładamy go na prawo i lewo, a następnie w górę i w dół. Jeżeli korporał jest źle zaprasowany i trzeba go odwrócić, uważamy aby ewentualne fragmenty Ciała Pańskiego nie upadły na ołtarz.
 * Jeżeli jest potrzeba przesunięcia go, łapiemy za jego rogi/krawędzie.
 
 {% hint style="danger" %}
 **Nigdy nie kładziemy rąk na korporale.**
 {% endhint %}
 
-* \(Następnie kładziemy puszki/pateny głębokie w jego lewym górnym rogu, a jeżeli jest ich więcej – wzdłuż lewej i górnej krawędzi.\)
+* \(Następnie kładziemy puszki/pateny głębokie w jego lewym górnym rogu, a jeżeli jest ich więcej – wzdłuż lewej i górnej krawędzi\).
 * Następnie przybliżamy kielich z puryfikaterzem \(i pateną\) do prawej krawędzi korporału.
 * Zdejmujemy patenę/Odbieramy patenę od drugiego ministranta i podajemy ją księdzu do rąk. Skłaniamy się i wracamy na swoje miejsce \(zabieramy welon kielichowy i przynosimy go przy okazji pomocy przy puryfikacji po Komunii\).
 

--- a/postawy.md
+++ b/postawy.md
@@ -170,7 +170,7 @@ Siedzenie oznacza gotowość do słuchania Słowa Bożego, nauki Kościoła.
 
 * Siedząc obok celebransa, na miejscu przewodniczenia, zawsze wstajemy gdy główny celebrans wraca do sedilli i siadamy razem z nim.
 * Nie garbimy się, nie oglądamy.
-* Ręce powinny spoczywać na kolanach. Nie obgryzujemy paznokci, skórek, etc. \(jedzenie wszelkich pokarmów, w tym również części naskórka czy paznokci jest złamaniem postu eucharystycznego – więcej w [Przyjmowanie Komunii świętej](przyjmowanie-komunii-swietej.md#kodeksu-prawa-kanonicznego)\)
+* Ręce powinny spoczywać na kolanach. Nie obgryzujemy paznokci, skórek, etc. \(jedzenie wszelkich pokarmów, w tym również części naskórka czy paznokci jest złamaniem postu eucharystycznego – więcej w [Przyjmowanie Komunii świętej](przyjmowanie-komunii-swietej.md#kodeksu-prawa-kanonicznego)\).
 * Nie machamy nogami w powietrzu, nie zakładamy nogi na nogę i nie pukamy nimi.
 * Nie bawimy się włosami.
 

--- a/postawy.md
+++ b/postawy.md
@@ -11,13 +11,13 @@
 ## Zasady ogólne
 
 * W trakcie Mszy każdy gest wyraża nasz szacunek do Boga.
-* Ministrant powinien mieć wyraz twarzy pogodny, naturalny, skupiony i pobożny. \(Przed wyjściem z zakrystii, w czasie przygotowań do Mszy spójrz w lustro, oceń swój wygląd, ułóż włosy, popraw ubiór, zadbaj o całą sylwetkę. Zwróć uwagę na innych ministrantów, pomóż dostrzec to czego nie widać... człowiek nie jest kameleonem i nie widzi niczego z tyłu głowy.\) Nasza postawa powinna uzewnętrzniać radość z prawdziwie wielkiej służby, jaką możemy pełnić.
+* Ministrant powinien mieć wyraz twarzy pogodny, naturalny, skupiony i pobożny. \(Przed wyjściem z zakrystii, w czasie przygotowań do Mszy spójrz w lustro, oceń swój wygląd, ułóż włosy, popraw ubiór, zadbaj o całą sylwetkę. Zwróć uwagę na innych ministrantów, pomóż dostrzec to czego nie widać... człowiek nie jest kameleonem i nie widzi niczego z tyłu głowy\). Nasza postawa powinna uzewnętrzniać radość z prawdziwie wielkiej służby, jaką możemy pełnić.
 * W trakcie liturgii nie ma miejsca dla pośpiechu.
 * Jeżeli daną funkcję wykonujemy z drugim ministrantem, staramy się aby razem wykonywać ją tak samo, w miarę symetrycznie, dotrzymując tempa.
 * Rzeczą co najmniej niestosowną jest ostentacyjne "grzebanie" w miejscu publicznym, w nosie, uszach, zębach, i innych otworach ciała, lub uporczywe drapanie, wycieranie nosa ręką \(do tego służy zawsze czysta chusteczka, a samą czynność wykonujemy dyskretnie, odwracając się delikatnie tyłem do wiernych\).
 * Przy ziewaniu zasłaniamy zawsze usta dłonią. Nikt z ludu nie musi oglądać twojego żołądka.
 * Nie kręcimy się, obracamy, przeciągamy.
-* Nie rozmawiamy, rozśmieszamy, dyskutujemy. \(Jeżeli już musisz porozumieć się z sąsiadem, w bardzo ważnej kwestii dotyczącej obecnie sprawowanej liturgii, to zrób tę czynność jak najbardziej dyskretnie ograniczając się do minimum słów.\) **Kategorycznie nie rozmawiamy podczas Przeistoczenia!**
+* Nie rozmawiamy, rozśmieszamy, dyskutujemy. \(Jeżeli już musisz porozumieć się z sąsiadem, w bardzo ważnej kwestii dotyczącej obecnie sprawowanej liturgii, to zrób tę czynność jak najbardziej dyskretnie ograniczając się do minimum słów\). **Kategorycznie nie rozmawiamy podczas Przeistoczenia!**
 * Staramy się nie rozglądać po kościele, nie wyszukujemy osób, sytuacji, które mogą nas rozpraszać, rozśmieszać. Jeżeli już zdarzyła się taka sytuacja staramy się skupić uwagę na ołtarzu, powstrzymać niewłaściwe emocje.
 * Gdy potrzebujemy sięgnąć po przedmiot położony nisko, lepiej jest przyklęknąć i wtedy go zabrać, niż "wypinać się" do innych.
 

--- a/triduum-paschalne/wielki-piatek.md
+++ b/triduum-paschalne/wielki-piatek.md
@@ -88,7 +88,7 @@ Kolejność procesji wejścia – według wzrostu:
 * **Pateny**
 * **Ministranci do pomocy przy adoracji Krzyża po Mszy**
 
-#### **Męka Pańska wg. św. Jana**
+#### **Męka Pańska wg św. Jana**
 
 * **✠** **Chrystus** – Celebrans/Diakon
 * **E. Ewangelista**

--- a/wizyta-duszpasterska.md
+++ b/wizyta-duszpasterska.md
@@ -28,7 +28,7 @@ Ministranci przychodzą do zakrystii minimum 30 minut przed godziną rozpoczęci
 Ministranci ubierają komżę pod kurtkę, odbierają od księdza materiały duszpasterskie i wraz z wyznaczonym kapłanem udają się na miejsce kolędy.  
 Ministranci razem z księdzem wchodzą do pierwszej rodziny, która przyjmuje wizytę. Jej przebieg zazwyczaj jest dosyć spontaniczny i różni się od przedstawionego poniżej wzorca.
 
-Za zgodą pierwszej rodziny pozostawiamy u niej wierzchnie ubrania aż do momentu przejścia do następnej klatki a w przypadku domków jednorodzinnych zawsze nosimy je na sobie. \(Nieraz pozostawiamy ubrania dopiero w drugim lub trzecim mieszkaniu ze względu na wyjście mieszkańców lub z powodu unoszącego się w mieszkaniu przykrego zapachu np. dymu papierosowego – po godzinie nasze ubrania będą nim przesiąknięte.\)
+Za zgodą pierwszej rodziny pozostawiamy u niej wierzchnie ubrania aż do momentu przejścia do następnej klatki a w przypadku domków jednorodzinnych zawsze nosimy je na sobie. \(Nieraz pozostawiamy ubrania dopiero w drugim lub trzecim mieszkaniu ze względu na wyjście mieszkańców lub z powodu unoszącego się w mieszkaniu przykrego zapachu np. dymu papierosowego – po godzinie nasze ubrania będą nim przesiąknięte\).
 
 ## Przebieg wizyty
 
@@ -71,7 +71,7 @@ Jest to:
 * **1,50 zł/mieszkanie**, które przyjęło wizytę, gdy chodzi **dwóch ministrantów**,
 * **2,00 zł/mieszkanie**, które przyjęło wizytę, gdy chodzi **jeden ministrant**.
 
-**Przypominam, że te pieniądze nie są przeznaczone "dla księdza". Są one odkładane na wspólną kasę ministrancką, z której później finansowane są np. wyjazdy wakacyjne i szaty ministranckie.** \(Spotkałem się już niejednokrotnie z pytaniami o oddawaną przez ministrantów kwotę i stwierdzeniami "po co jeszcze ksiądz zabiera ministrantom pieniądze, skoro od mieszkańców dostaje już w tzw. kopercie". Prostujmy te błędne opinie.\)
+**Przypominam, że te pieniądze nie są przeznaczone "dla księdza". Są one odkładane na wspólną kasę ministrancką, z której później finansowane są np. wyjazdy wakacyjne i szaty ministranckie.** \(Spotkałem się już niejednokrotnie z pytaniami o oddawaną przez ministrantów kwotę i stwierdzeniami "po co jeszcze ksiądz zabiera ministrantom pieniądze, skoro od mieszkańców dostaje już w tzw. kopercie". Prostujmy te błędne opinie\).
 
 Na zakończenie wkładamy do niej kartkę z numerami mieszkań, zaklejamy kopertę i oddajemy kapłanowi.  
 Idziemy po swoje ubrania.


### PR DESCRIPTION
Fixing: 

- Period sign ending the sentence should be after the closing bracket like so `).`.
- `Według` abbreviation is `wg` without a period.
- Missing period at the end of the sentence.